### PR TITLE
Update Dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: 'thursday'
     groups:
       nonMajor:
         patterns:
@@ -14,4 +15,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: 'thursday'


### PR DESCRIPTION
This pull request updates the Dependabot configuration to increase the frequency of dependency checks for both npm packages and GitHub Actions. Instead of running monthly, Dependabot will now check for updates weekly, specifically on Thursdays.

Dependabot configuration updates:

* Changed the update schedule for both npm and GitHub Actions ecosystems from monthly to weekly, and specified Thursday as the update day in `.github/dependabot.yml`. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R7) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R19)